### PR TITLE
Fix deprecated calls to jax.tree_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ In order to use JAX on your accelerators, you can find more details in the [JAX 
   )
 
   # Multiple rollouts for different networks + rng (e.g. for ES)
-  batch_params = jax.tree_map(  # Stack parameters or use different
+  batch_params = jax.tree.map(  # Stack parameters or use different
       lambda x: jnp.tile(x, (5, 1)).reshape(5, *x.shape), policy_params
   )
   obs, action, reward, next_obs, done, cum_ret = manager.population_rollout(

--- a/examples/01_anakin.ipynb
+++ b/examples/01_anakin.ipynb
@@ -212,8 +212,8 @@
     "    learn = jax.pmap(learn, axis_name='i')  # replicate over multiple cores.\n",
     "\n",
     "    broadcast = lambda x: jnp.broadcast_to(x, (cores_count, batch_size) + x.shape)\n",
-    "    params = jax.tree_map(broadcast, params)  # broadcast to cores and batch.\n",
-    "    opt_state = jax.tree_map(broadcast, opt_state)  # broadcast to cores and batch\n",
+    "    params = jax.tree.map(broadcast, params)  # broadcast to cores and batch.\n",
+    "    opt_state = jax.tree.map(broadcast, opt_state)  # broadcast to cores and batch\n",
     "\n",
     "    rng, *env_rngs = jax.random.split(rng, cores_count * batch_size + 1)\n",
     "    env_obs, env_states = jax.vmap(env.reset)(jnp.stack(env_rngs))  # init envs.\n",
@@ -251,8 +251,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/_src/tree_util.py:188: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() instead as a drop-in replacement.\n",
-      "  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() '\n"
+      "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/_src/tree_util.py:188: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree.map() instead as a drop-in replacement.\n",
+      "  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree.map() '\n"
      ]
     },
     {
@@ -285,7 +285,7 @@
     "# Get model ready for evaluation - squeeze broadcasted params\n",
     "model = get_network_fn(env.num_actions)\n",
     "squeeze = lambda x: x[0][0]\n",
-    "params = jax.tree_map(squeeze, batch_params)\n",
+    "params = jax.tree.map(squeeze, batch_params)\n",
     "\n",
     "# Simple single episode rollout for policy\n",
     "rng = jax.random.PRNGKey(0)"

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -435,7 +435,7 @@
     ")\n",
     "\n",
     "# Multiple rollouts for different networks + rng (e.g. for ES)\n",
-    "batch_params = jax.tree_map(  # Stack parameters or use different\n",
+    "batch_params = jax.tree.map(  # Stack parameters or use different\n",
     "    lambda x: jnp.tile(x, (5, 1)).reshape(5, *x.shape), policy_params\n",
     ")\n",
     "obs, action, reward, next_obs, done, cum_ret = manager.population_rollout(\n",

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -59,7 +59,7 @@ class Environment(Generic[TEnvState, TEnvParams]):  # object):
         obs_st, state_st, reward, done, info = self.step_env(key, state, action, params)
         obs_re, state_re = self.reset_env(key_reset, params)
         # Auto-reset environment based on termination
-        state = jax.tree_map(
+        state = jax.tree.map(
             lambda x, y: jax.lax.select(done, x, y), state_re, state_st
         )
         obs = jax.lax.select(done, obs_re, obs_st)

--- a/gymnax/wrappers/gym.py
+++ b/gymnax/wrappers/gym.py
@@ -197,5 +197,5 @@ class GymnaxToVectorGymWrapper(gym.vector.VectorEnv):
     ) -> Optional[Union[core.RenderFrame, List[core.RenderFrame]]]:
         """use underlying environment rendering if it exists (for first environment), otherwise return None."""
         return getattr(self._env, "render", lambda x, y: None)(
-            jax.tree_map(lambda x: x[0], self.env_state), self.env_params
+            jax.tree.map(lambda x: x[0], self.env_state), self.env_params
         )

--- a/tests/wrappers/test_evaluator.py
+++ b/tests/wrappers/test_evaluator.py
@@ -44,11 +44,11 @@ def test_rollout():
     assert obs.shape == (10, 150, 3)
 
     # Test multiple rollouts for different networks
-    batch_params = jax.tree_map(
+    batch_params = jax.tree.map(
         lambda x: jnp.tile(x, (5, 1)).reshape(5, *x.shape), policy_params
     )
-    # print(jax.tree_map(lambda x: x.shape, policy_params))
-    # print(jax.tree_map(lambda x: x.shape, batch_params))
+    # print(jax.tree.map(lambda x: x.shape, policy_params))
+    # print(jax.tree.map(lambda x: x.shape, batch_params))
     (
         obs,
         _,


### PR DESCRIPTION
This PR replaces calls to deprecated `jax.tree_map` with `jax.tree.map` so that this library works with newer versions of `jax`.