### PR TITLE
Remove flax as dependency, also fix purerl LogWrapper

### DIFF
--- a/gymnax/environments/bsuite/bandit.py
+++ b/gymnax/environments/bsuite/bandit.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/bsuite/catch.py
+++ b/gymnax/environments/bsuite/catch.py
@@ -9,7 +9,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/bsuite/deep_sea.py
+++ b/gymnax/environments/bsuite/deep_sea.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/bsuite/discounting_chain.py
+++ b/gymnax/environments/bsuite/discounting_chain.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/bsuite/memory_chain.py
+++ b/gymnax/environments/bsuite/memory_chain.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/bsuite/mnist.py
+++ b/gymnax/environments/bsuite/mnist.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 from gymnax.utils import load_mnist

--- a/gymnax/environments/bsuite/umbrella_chain.py
+++ b/gymnax/environments/bsuite/umbrella_chain.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/classic_control/acrobot.py
+++ b/gymnax/environments/classic_control/acrobot.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/classic_control/cartpole.py
+++ b/gymnax/environments/classic_control/cartpole.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/classic_control/continuous_mountain_car.py
+++ b/gymnax/environments/classic_control/continuous_mountain_car.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/classic_control/mountain_car.py
+++ b/gymnax/environments/classic_control/mountain_car.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/classic_control/pendulum.py
+++ b/gymnax/environments/classic_control/pendulum.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/environment.py
+++ b/gymnax/environments/environment.py
@@ -9,7 +9,7 @@ from typing import (
 )
 
 import jax
-from flax import struct
+from gymnax.utils import struct
 
 TEnvState = TypeVar("TEnvState", bound="EnvState")
 TEnvParams = TypeVar("TEnvParams", bound="EnvParams")

--- a/gymnax/environments/minatar/asterix.py
+++ b/gymnax/environments/minatar/asterix.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/minatar/breakout.py
+++ b/gymnax/environments/minatar/breakout.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/minatar/freeway.py
+++ b/gymnax/environments/minatar/freeway.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/minatar/seaquest.py
+++ b/gymnax/environments/minatar/seaquest.py
@@ -2,7 +2,7 @@
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/minatar/space_invaders.py
+++ b/gymnax/environments/minatar/space_invaders.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/misc/bernoulli_bandit.py
+++ b/gymnax/environments/misc/bernoulli_bandit.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/misc/gaussian_bandit.py
+++ b/gymnax/environments/misc/gaussian_bandit.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/misc/meta_maze.py
+++ b/gymnax/environments/misc/meta_maze.py
@@ -10,7 +10,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/misc/point_robot.py
+++ b/gymnax/environments/misc/point_robot.py
@@ -5,7 +5,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/misc/pong.py
+++ b/gymnax/environments/misc/pong.py
@@ -12,7 +12,7 @@ import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import seaborn as sns
-from flax import struct
+from gymnax.utils import struct
 from matplotlib import colors
 
 from gymnax.environments import environment, spaces

--- a/gymnax/environments/misc/reacher.py
+++ b/gymnax/environments/misc/reacher.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/misc/rooms.py
+++ b/gymnax/environments/misc/rooms.py
@@ -10,7 +10,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/environments/misc/swimmer.py
+++ b/gymnax/environments/misc/swimmer.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 

--- a/gymnax/utils/struct.py
+++ b/gymnax/utils/struct.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass as _dataclass
+from dataclasses import field as _field
+from dataclasses import fields as _fields
+from dataclasses import replace as _dc_replace
+from typing import Any, Callable, Iterable, Tuple
+
+import jax
+
+
+def dataclass(_cls: type | None = None, *, frozen: bool = True):
+    """A lightweight JAX-friendly dataclass.
+
+    - Wraps stdlib dataclass (default frozen=True)
+    - Registers the class as a JAX PyTree
+    - Adds an instance method `.replace(**updates)` similar to flax.struct
+    - Supports marking static fields via `metadata={"pytree_node": False}`
+    """
+
+    def wrap(cls: type):
+        dc = _dataclass(frozen=frozen)(cls)
+        dc_fields = _fields(dc)
+        names = tuple(f.name for f in dc_fields)
+        pytree_mask = tuple(bool(f.metadata.get("pytree_node", True)) for f in dc_fields)
+
+        def flatten(obj: Any) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+            children = []
+            static = []
+            for name, is_node in zip(names, pytree_mask):
+                val = getattr(obj, name)
+                if is_node:
+                    children.append(val)
+                else:
+                    static.append(val)
+            # Use names and mask to reconstruct reliably
+            aux = (names, pytree_mask, tuple(static))
+            return tuple(children), aux
+
+        def unflatten(aux: Tuple[Iterable[str], Iterable[bool], Tuple[Any, ...]],
+                      children: Tuple[Any, ...]):
+            names_aux, mask_aux, static_vals = aux
+            out_kwargs = {}
+            c_it = iter(children)
+            s_it = iter(static_vals)
+            for name, is_node in zip(names_aux, mask_aux):
+                out_kwargs[name] = next(c_it) if is_node else next(s_it)
+            return dc(**out_kwargs)
+
+        # Register as PyTree once per class
+        jax.tree_util.register_pytree_node(dc, flatten, unflatten)
+
+        # Attach replace method for convenience
+        def _replace(self, **updates):
+            return _dc_replace(self, **updates)
+
+        setattr(dc, "replace", _replace)
+        return dc
+
+    if _cls is None:
+        return wrap
+    return wrap(_cls)
+
+
+# Re-export field so code can do `from gymnax.utils import struct; struct.field(...)`
+field = _field

--- a/gymnax/wrappers/dm_env.py
+++ b/gymnax/wrappers/dm_env.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment
 from gymnax.wrappers import purerl

--- a/gymnax/wrappers/evojax.py
+++ b/gymnax/wrappers/evojax.py
@@ -10,7 +10,7 @@ try:
 except Exception as exc:
     raise ImportError("You need to additionally install EvoJAX.") from exc
 
-from flax import struct
+from gymnax.utils import struct
 
 
 @struct.dataclass

--- a/gymnax/wrappers/purerl.py
+++ b/gymnax/wrappers/purerl.py
@@ -6,7 +6,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import numpy as np
-from flax import struct
+from gymnax.utils import struct
 
 from gymnax.environments import environment, spaces
 
@@ -24,9 +24,6 @@ class GymnaxWrapper:
 
 class FlattenObservationWrapper(GymnaxWrapper):
     """Flatten the observations of the environment."""
-
-    #   def __init__(self, env: environment.Environment):
-    #     super().__init__(env)
 
     def observation_space(self, params) -> spaces.Box:
         assert isinstance(self._env.observation_space(params), spaces.Box), (
@@ -72,15 +69,12 @@ class LogEnvState:
 class LogWrapper(GymnaxWrapper):
     """Log the episode returns and lengths."""
 
-    #   def __init__(self, env: environment.Environment):
-    #     super().__init__(env)
-
     @partial(jax.jit, static_argnames=("self",))
     def reset(
         self, key: jax.Array, params: environment.EnvParams | None = None
     ) -> tuple[jax.Array, LogEnvState]:
         obs, env_state = self._env.reset(key, params)
-        state = LogEnvState(env_state, 0, 0, 0, 0)
+        state = LogEnvState(env_state, 0.0, 0, 0.0, 0)
         return obs, state
 
     @partial(jax.jit, static_argnames=("self",))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 dependencies = [
     "jax",
-    "flax",
     "gymnasium",
     "matplotlib",
     "seaborn",
@@ -32,7 +31,6 @@ dev = [
 ]
 test = [
     "chex",
-    "flax",
     "brax",
     "minatar",
 ]


### PR DESCRIPTION
Flax is broken with latest jax/python, yet again. Flax introduces a large number of dependencies, even though gymnax only requires `struct.dataclass` from jax. This commit implements `struct.dataclass` and  removes flax as a dependency to prevent future breakages.